### PR TITLE
Fix incorrect usage output.

### DIFF
--- a/include/rwahs/tasks/deploy
+++ b/include/rwahs/tasks/deploy
@@ -19,7 +19,7 @@ function deploy_showHelp {
     echo "release the 'current' version in the given environment."
     echo
     echo "USAGE:"
-    echo "    ${programName} deploy -e <environment> -c <component> [-r <release>]"
+    echo "    ${programName} deploy -e <environment> -c <component> -r <release>"
     echo
     echo "WHERE:"
     echo "    -c <component> gives the name of the component to process."


### PR DESCRIPTION
- `-r` is required for `deploy` task, but was marked as optional.
