### PR TITLE
Change file structure on servers

### DIFF
--- a/config/rwahs/components/configuration
+++ b/config/rwahs/components/configuration
@@ -8,7 +8,7 @@ set -u
 
 repo='rwahs/providence-configuration'
 repoDefaultTargetCommitish='master'
-targetParent='local/providence-configuration'
+targetParent='providence-configuration'
 
 function preDeploy {
     sudo service apache2 stop

--- a/config/rwahs/components/importer
+++ b/config/rwahs/components/importer
@@ -8,4 +8,4 @@ set -u
 
 repo='rwahs/import-scripts'
 repoDefaultTargetCommitish='master'
-targetParent='local/import-scripts'
+targetParent='import-scripts'

--- a/config/rwahs/components/profile
+++ b/config/rwahs/components/profile
@@ -8,4 +8,4 @@ set -u
 
 repo='rwahs/installation-profile'
 repoDefaultTargetCommitish='master'
-targetParent='local/installation-profile'
+targetParent='installation-profile'

--- a/config/rwahs/components/providence
+++ b/config/rwahs/components/providence
@@ -8,7 +8,7 @@ set -u
 
 repo='rwahs/providence'
 repoDefaultTargetCommitish='master-fix'
-targetParent='web/providence'
+targetParent='providence'
 
 function preDeploy {
     if [ ! -v COLLECTIVEACCESS_HOME ]; then

--- a/config/rwahs/components/tools
+++ b/config/rwahs/components/tools
@@ -8,4 +8,4 @@ set -u
 
 repo='rwahs/tools'
 repoDefaultTargetCommitish='master'
-targetParent='local/tools'
+targetParent='tools'

--- a/config/rwahs/env/staging
+++ b/config/rwahs/env/staging
@@ -8,5 +8,5 @@ set -u
 
 host='52.62.226.104'
 user='ca'
-targetRoot='/data'
+targetRoot='/data/deploy'
 adminEmailAddress='rwahs@gaiaresources.com.au'

--- a/config/rwahs/env/uat
+++ b/config/rwahs/env/uat
@@ -8,5 +8,5 @@ set -u
 
 host='52.63.20.116'
 user='ca'
-targetRoot='/data'
+targetRoot='/data/deploy'
 adminEmailAddress='rwahs@gaiaresources.com.au'


### PR DESCRIPTION
- Instead of rooting the deployments at `/data` and then components
  specifying a path like `web/providence` or `local/tools`, the deployments
  are now rooted at `/data/deploy` and each component deploys itself into
  an immediate child folder.  There are symlinks to other locations as required.
- This allows the use of `/data/local` to change to containing only local
  machine specific configuration.
