### PR TITLE
Fix variable default value syntax.

### DIFF
--- a/bin/rwahs
+++ b/bin/rwahs
@@ -88,12 +88,12 @@ function getRemoteCommand {
     environment=$(getEnvironmentOption $@)
 
     # To run remotely, either `environment` and `RWAHS_ENV` are both
-    if [ "${environment-${RWAHS_ENV-}}" != "${RWAHS_ENV-}" ]; then
+    if [ "${environment:-${RWAHS_ENV:-}}" != "${RWAHS_ENV:-}" ]; then
         # Include the tools component configuration, so we know where to run the command from.
         source "${toolsDir}/config/${programName}/components/tools"
 
         # Include the environment configuration for the SSH parameters.
-        source "${toolsDir}/config/${programName}/env/${environment-${RWAHS_ENV-}}"
+        source "${toolsDir}/config/${programName}/env/${environment:-${RWAHS_ENV:-}}"
 
         # Output the command to run; this is captured by the calling function.
         echo ssh "${user}@${host}" "${targetRoot}/${targetParent}/current/bin/${programName} ${task} $@"

--- a/include/rwahs/tasks/deploy
+++ b/include/rwahs/tasks/deploy
@@ -43,7 +43,7 @@ function deploy_runTask {
     shift 2
 
     # Default values
-    environment=${RWAHS_ENV-}
+    environment=${RWAHS_ENV:-}
 
     # Parse parameters
     while getopts :c:e:br: parameter; do

--- a/include/rwahs/tasks/import
+++ b/include/rwahs/tasks/import
@@ -40,7 +40,7 @@ function import_runTask {
     shift 2
 
     # Default values
-    environment=${RWAHS_ENV-}
+    environment=${RWAHS_ENV:-}
 
     # Parse parameters
     while getopts :e:n parameter; do

--- a/include/rwahs/tasks/nuke
+++ b/include/rwahs/tasks/nuke
@@ -38,7 +38,7 @@ function nuke_runTask {
     shift 2
 
     # Default values
-    environment=${RWAHS_ENV-}
+    environment=${RWAHS_ENV:-}
 
     # Parse parameters
     while getopts :e: parameter; do


### PR DESCRIPTION
- `${variable-default}` will substitute `default` only if `${variable}`
  is unset (not empty).
- `${variable:-default}` will substitute `default` if `${variable}` is
  either unset or empty.
- We actually want the latter, and now that's what we have.
