### PR TITLE
Make the `nuke` command actually do something

### DIFF
--- a/include/rwahs/tasks/nuke
+++ b/include/rwahs/tasks/nuke
@@ -83,7 +83,7 @@ function nuke_runTask {
 
     # Do the work
     echo "Running 'nuke' task..."
-    echo ${COLLECTIVEACCESS_HOME}/support/bin/caUtils install \
+    ${COLLECTIVEACCESS_HOME}/support/bin/caUtils install \
         --profile-directory "${targetRoot}/${targetParent}/current/profile" \
         --profile-name "rwahs" \
         --admin-email "${adminEmailAddress}" \


### PR DESCRIPTION
- rather than just saying it's doing it and then not
